### PR TITLE
test: update sft test coverage

### DIFF
--- a/contracts/BaseSFT.sol
+++ b/contracts/BaseSFT.sol
@@ -5,12 +5,20 @@ import {IERC165} from "@openzeppelin/contracts/interfaces/IERC165.sol";
 
 import {ERC1155} from "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
 import {ERC1155Supply} from "@openzeppelin/contracts/token/ERC1155/extensions/ERC1155Supply.sol";
+import {ERC1155Burnable} from "@openzeppelin/contracts/token/ERC1155/extensions/ERC1155Burnable.sol";
 import {ERC2981} from "@openzeppelin/contracts/token/common/ERC2981.sol";
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
 
-contract BaseSFT is IERC165, ERC1155Supply, ERC2981, Ownable, Pausable {
+contract BaseSFT is
+    IERC165,
+    ERC1155Supply,
+    ERC1155Burnable,
+    ERC2981,
+    Ownable,
+    Pausable
+{
     error InvalidTokenIDRange(uint256 minTokenID, uint256 maxTokenID);
     error TokenIDRangeFrozen();
 
@@ -210,7 +218,7 @@ contract BaseSFT is IERC165, ERC1155Supply, ERC2981, Ownable, Pausable {
         address to,
         uint256[] memory ids,
         uint256[] memory values
-    ) internal override {
+    ) internal override(ERC1155, ERC1155Supply) {
         super._update(from, to, ids, values);
 
         for (uint256 i = 0; i < ids.length; i++) {

--- a/contracts/BaseSFT.sol
+++ b/contracts/BaseSFT.sol
@@ -26,7 +26,7 @@ contract BaseSFT is IERC165, ERC1155Supply, ERC2981, Ownable, Pausable {
 
     error InsufficientBalance(address holder, uint256 tokenID);
     error InvalidHoldingThreshold();
-    error HoldingThresholdsFrozen(uint256 tokenID);
+    error HoldingThresholdFrozen(uint256 tokenID);
 
     // indicate to OpenSea that an NFT's metadata is frozen
     event PermanentURI(string uri, uint256 indexed tokenID);
@@ -265,6 +265,13 @@ contract BaseSFT is IERC165, ERC1155Supply, ERC2981, Ownable, Pausable {
         emit PermanentURI(_tokenURIs[tokenID_], tokenID_);
     }
 
+    function freezeHoldingThreshold(uint256 tokenID_) external onlyOwner {
+        _requireExists(tokenID_);
+        _requireHoldingThresholdsNotFrozen(tokenID_);
+
+        _isHoldingThresholdFrozen[tokenID_] = true;
+    }
+
     function _requireTokenIDRangeNotFrozen() internal view {
         require(!_isTokenIDRangeFrozen, TokenIDRangeFrozen());
     }
@@ -276,7 +283,7 @@ contract BaseSFT is IERC165, ERC1155Supply, ERC2981, Ownable, Pausable {
     function _requireHoldingThresholdsNotFrozen(uint256 tokenID) internal view {
         require(
             !_isHoldingThresholdFrozen[tokenID],
-            HoldingThresholdsFrozen(tokenID)
+            HoldingThresholdFrozen(tokenID)
         );
     }
 }

--- a/test/SampleSFT.test.ts
+++ b/test/SampleSFT.test.ts
@@ -191,22 +191,6 @@ describe(SFT_CONTRACT_NAME, () => {
       expect(await sft.balanceOf(holder1.address, 1)).to.equal(0);
       expect(await sft.balanceOf(holder2.address, 1)).to.equal(1);
     });
-
-    it("failure: cannot burn", async () => {
-      await sft.unpause();
-      await sft.addMinter(minter.address);
-
-      await sft.connect(minter).airdrop(holder1.address, 1, 1);
-      expect(await sft.balanceOf(holder1.address, 1)).to.equal(1);
-
-      await expect(
-        sft
-          .connect(holder1)
-          .safeTransferFrom(holder1.address, ethers.ZeroAddress, 1, 1, "0x")
-      )
-        .to.be.revertedWithCustomError(sft, "ERC1155InvalidReceiver")
-        .withArgs(ethers.ZeroAddress);
-    });
   });
 
   describe("royalty", () => {
@@ -403,6 +387,15 @@ describe(SFT_CONTRACT_NAME, () => {
       await sft.connect(minter).airdrop(holder2.address, 1, 1);
       expect(await sft.balanceOf(holder2.address, 1)).to.equal(3);
       expect(await sft.holdingPeriod(holder2, 1)).to.equal(1001);
+
+      await sft.connect(holder2).burn(holder2.address, 1, 1);
+      expect(await sft.balanceOf(holder2.address, 1)).to.equal(2);
+      expect(await sft.holdingPeriod(holder2, 1)).to.equal(1002);
+      await sft.connect(holder2).burn(holder2.address, 1, 1);
+      expect(await sft.balanceOf(holder2.address, 1)).to.equal(1);
+      await expect(sft.holdingPeriod(holder2, 1))
+        .to.be.revertedWithCustomError(sft, "InsufficientBalance")
+        .withArgs(holder2.address, 1);
     });
 
     describe("setHodlingThreshold", () => {


### PR DESCRIPTION
* HoldingThreshold の freeze を忘れていたので実装
* ERC1155Burnable を継承して burn メソッドを増やした
* テストのカバレッジを上げた

```bash
$ pnpm hardhat coverage
------------------------|----------|----------|----------|----------|----------------|
File                    |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
------------------------|----------|----------|----------|----------|----------------|
  BaseSFT.sol           |      100 |      100 |      100 |      100 |                |
  IAirdroppableSFT.sol  |      100 |      100 |      100 |      100 |                |
  SampleSFT.sol         |      100 |      100 |      100 |      100 |                |
------------------------|----------|----------|----------|----------|----------------|
```